### PR TITLE
Update .dic 010 template

### DIFF
--- a/src/010 Templates/dic.bt
+++ b/src/010 Templates/dic.bt
@@ -1,58 +1,91 @@
 //------------------------------------------------
-//--- 010 Editor v12.0.1 Binary Template
+//--- 010 Editor v16.0.4 Binary Template
 //
-//      File: 
-//   Authors: 
-//   Version: 
-//   Purpose: 
-//  Category: 
-// File Mask: 
-//  ID Bytes: 
-//   History: Label DIC files
+//      File: dic.bt
+//   Authors: Petar Tasev, burninrubber0
+//   Version: 1.1
+//   Purpose: Parse Codemasters' Neon Sound Dictionary v2.00 files.
+//  Category: Game
+// File Mask: *.dic
+//  ID Bytes: 44 49 43 31, 44 49 43 32, 44 49 43 33, 44 49 43 34, 44 49 43 35, 44 49 43 36, 44 49 43 37 // DIC[1-7]
+//   History: 
+//   1.0: Original template.
+//   1.1: Rewrite based on debugging symbols.
 //------------------------------------------------
-LittleEndian();
 
-struct {
-    char magic[4];
-    uint unknown;
-    char version[4];
-    uint numBanks;
-} header;
+// Detect platform and set options.
+BigEndian();
+local uint sku = ReadUInt();
+if (sku != 0x44494333 && sku != 0x44494335 && sku != 0x44494337) // PS3, X360, WII
+    LittleEndian();
+BitfieldDisablePadding();
 
-struct {
-    uint sampleOffset;
-    uint numSamples;
-    char name[16];
+enum SkuId {
+    PC   = 0x31434944, // DIC1
+    PS2  = 0x32434944, // DIC2
+    PS3  = 0x44494333, // DIC3
+    XBOX = 0x34434944, // DIC4
+    X360 = 0x44494335, // DIC5
+    PSP  = 0x36434944, // DIC6
+    WII  = 0x44494337  // DIC7
+};
+enum Format {
+    PCM16_BIG    = 0, // 0x3010
+    PCM16_LITTLE = 1, // 0x3011
+    FLOAT32      = 2, // 0x3012
+    ADPCM        = 3, // 0x3013
+    ATRAC_LOW    = 4, // 0x3014
+    ATRAC_MEDIUM = 5, // 0x3015
+    ATRAC_HIGH   = 6  // 0x3016
+};
+struct Header {
+    SkuId sku <format=hex>; // Platform-specific magic.
+    uint uniqueId <format=hex>; // Per-dictionary unique hash. Source is not currently known.
+    char version[4]; // Padding field containing the version number of the format.
+    uint numBanks; // Number of banks.
+};
+// Because of how 010 handles bitfields, they have to be defined per-endianness.
+struct SampleFlags {
+    if (IsLittleEndian()) {
+        int sampleRate : 20; // Sample rate (Hz).
+        byte loop : 1; // The sample is looped.
+        byte numChannels : 3; // Number of channels minus 1.
+        byte reserved : 4; // Unused.
+        Format format : 3; // Audio format. Used on PS3 in P3A assets.
+        byte music : 1; // The sample is used as music.
+    } else {
+        byte music : 1; // The sample is used as music.
+        Format format : 3; // Audio format. Used on PS3 in P3A assets.
+        byte reserved : 4; // Unused.
+        byte numChannels : 3; // Number of channels minus 1.
+        byte loop : 1; // The sample is looped.
+        int sampleRate : 20; // Sample rate (Hz).
+    }
+};
+struct Sample {
+    uint offset <format=hex>; // Start address of the sample data in the audio file.
+    SampleFlags flags; // Sample flags. See structure above.
+    char name[16]; // Sample name.
+};
+struct BankTrailer {
+    uint length <format=hex>; // Offset of the end of the last sample.
+    char extension[4]; // File extension.
+};
+struct Bank {
+    uint offset <format=hex>; // Start address of the first sample.
+    uint numSamples; // Number of samples.
+    char name[16]; // Bank name.
+    
+    // Samples are pointed to by the bank, so they are shown here as part of it.
+    // Same with the trailer.
+    local int pos = FTell();
+    FSeek(offset);
+    
+    Sample samples[numSamples] <read=name, optimize=false>;
+    BankTrailer trailer;
+    
+    FSeek(pos);
+};
 
-    local int currPos = FTell();
-    FSeek(sampleOffset);
-
-    uint unknown;
-    struct {
-        uint16 sampleRate;
-        struct {
-            uint16 unk0 : 1;
-            uint16 unk1 : 1;
-            uint16 unk2 : 1;
-            uint16 unk3 : 1;
-            uint16 loop : 1;
-            uint16 stereo : 1;
-            uint16 unk6 : 1;
-            uint16 unk7 : 1;
-            uint16 unk8 : 1;
-            uint16 unk9 : 1;
-            uint16 unk10 : 1;
-            uint16 unk11 : 1;
-            uint16 unk12 : 1;
-            uint16 unk13 : 1;
-            uint16 unk14 : 1;
-            uint16 unk15 : 1;
-        } flags <bgcolor=cGreen>;
-        char name[16];
-        uint32 size;
-    } sample[numSamples] <read=name>;
-    char format[4];
-
-    FSeek(currPos);
-
-} bank[header.numBanks] <read=name,optimize=false>;
+Header header;
+Bank banks[header.numBanks] <read=name, optimize=false>;


### PR DESCRIPTION
Since it was brought up on Discord, I figured it might be worthwhile to update the template with the newest info we have. This is a full rewrite, but I tried to keep the user-facing stuff at least somewhat similar and reused a few names in so doing. It's also not a 1:1 match with the debugging symbols as some changes were warranted to make it more readable.

Most of the changes boil down to filling in unknowns. There's also support for big endian dictionaries now. In theory, it should be possible to read any file that uses this version of this format now.

There aren't currently any colors set but that's easy enough to change if requested.